### PR TITLE
Changed sampling parameters to lighten the analysis

### DIFF
--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "## Tutorial 3.2: Parameter estimation for compact object mergers\n",
     "\n",
-    "In this tutorial, we will learn how to run our own parameter estimation analysis for compact object mergers using the [bilby Bayesian inference library](https://lscsoft.docs.ligo.org/bilby/). Specifically, we will analyse the first detection, GW150914 using open data. Typically, a full analysis using stochastic sampling on a personal computer can take many hours if not days. Therefore, this analysis will be restricted to a non-spinning binary black hole model and neglect the marginalization of the calibration uncertainty. This will take about 40 minutes to run (note that a bottleneck is given by the first cell in the Section \"Create a likelihood-Run the analysis\": computational time depends a lot on the machine you decide to run, on Google Colab is about 25 minutes this cell only).\n",
+    "In this tutorial, we will learn how to run our own parameter estimation analysis for compact object mergers using the [bilby Bayesian inference library](https://lscsoft.docs.ligo.org/bilby/). Specifically, we will analyse the first detection, GW150914 using open data. Typically, a full analysis using stochastic sampling on a personal computer can take many hours if not days. Therefore, this analysis will be restricted to a non-spinning binary black hole model and neglect the marginalization of the calibration uncertainty. This will take about 30 minutes to run (note that a bottleneck is given by the first cell in the Section \"Create a likelihood-Run the analysis\": computational time depends a lot on the machine you decide to run, on Google Colab is about 10 minutes this cell only).\n",
     "   \n",
     "   \n",
     "You can find more examples of using bilby here: https://lscsoft.docs.ligo.org/bilby/examples.html\n",
@@ -758,7 +758,7 @@
     "result_short = bilby.run_sampler(\n",
     "    likelihood, prior, sampler='dynesty', outdir='short', label=\"GW150914\",\n",
     "    conversion_function=bilby.gw.conversion.generate_all_bbh_parameters,\n",
-    "    nlive=500, dlogz=0.5,  # <- Arguments are used to make things fast - not recommended for general use\n",
+    "    nlive=250, dlogz=1.,  # <- Arguments are used to make things fast - not recommended for general use\n",
     "    clean=True,\n",
     ")"
    ]


### PR DESCRIPTION
About Tutorial 3.2 as suggested I changed sampling parameters
nlive=500, dlogz=0.5
to
nlive=250, dlogz=1
The execution of the cell "Create a likelihood-Run the analysis" now takes more or less 10 minutes on Google Colab (instead of the 25 before), which I think it starts to be a reasonable time (even if not that short).
No major differences has been found in the analysis results
