### PR TITLE
minor typos corrected in Tuto_3.1

### DIFF
--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -261,7 +261,7 @@
     "\n",
     "This definition of how the data was created allows us to define our likelihood. Namely, given a value of $f, \\alpha$, the likelihood of a single data point $y_i$ (measured at $t_i$) is:\n",
     "\n",
-    "$$ \\mathcal{L}(y_i| f, \\alpha, M_s) = \\frac{1}{\\sqrt{2\\pi \\sigma^2}} \\exp\\left(-\\frac{(y_i - s(t_i; f, \\alpha))^2}{\\sigma}\\right) $$\n",
+    "$$ \\mathcal{L}(y_i| f, \\alpha, M_s) = \\frac{1}{\\sqrt{2\\pi \\sigma^2}} \\exp\\left(-\\frac{(y_i - s(t_i; f, \\alpha))^2}{2\\sigma^2}\\right) $$\n",
     "\n",
     "To extend this to multiple data points, we assume they are independent then\n",
     "\n",
@@ -269,7 +269,7 @@
     "\n",
     "In practice, it is wise to work with the logarithm of the likelihood to avoid numerical overflow. Then, we have that\n",
     "\n",
-    "$$ \\log \\mathcal{L}(y_{obs} | f, \\alpha, M_s) = \\sum_{i} -\\frac{1}{2}\\left(\\frac{\\left(y_i - s(t_i; f, \\alpha)\\right)^2}{\\sigma^2} - \\log\\left(2\\pi \\sigma^2\\right)\\right) $$\n",
+    "$$ \\log \\mathcal{L}(y_{obs} | f, \\alpha, M_s) = \\sum_{i} -\\frac{1}{2}\\left(\\frac{\\left(y_i - s(t_i; f, \\alpha)\\right)^2}{\\sigma^2} + \\log\\left(2\\pi \\sigma^2\\right)\\right) $$\n",
     "\n",
     "We now transcribe this into `python`:"
    ]
@@ -1151,7 +1151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Two minor typos were corrected in the (sub-)section  "Parameter Estimation: Likelihood". The second equation should have $2\sigma^2$ instead of $\sigma$ inside the exponential, and in the last equation, it should be "$+ \log(2\pi\sigma^2)$" instead of  "$- \log(2\pi\sigma^2)$" inside the parenthesis. 